### PR TITLE
Deprecate usage of `.data` in tidyselect functions

### DIFF
--- a/R/add_sector_and_borderline.R
+++ b/R/add_sector_and_borderline.R
@@ -117,8 +117,8 @@ rename_as_loanbook <- function(classification) {
   classification %>%
     check_crucial_names(c("code_system", "code")) %>%
     dplyr::rename(
-      sector_classification_system = .data$code_system,
-      sector_classification_direct_loantaker = .data$code
+      sector_classification_system = "code_system",
+      sector_classification_direct_loantaker = "code"
     )
 }
 

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -207,7 +207,7 @@ match_name_impl <- function(loanbook,
 
   matched <- reorder_names_as_in_loanbook(matched, loanbook_rowid)
   matched <- unsuffix_and_regroup(matched, old_groups)
-  matched <- select(matched, -.data$alias, -.data$alias_abcd)
+  matched <- select(matched, -all_of(c("alias", "alias_abcd")))
   # Remove attribute added by data.table
   attr(matched, ".internal.selfref") <- NULL
 
@@ -261,7 +261,7 @@ empty_loanbook_tibble <- function(loanbook, old_groups) {
 
   out <- named_tibble(names = minimum_names_of_match_name(loanbook)) %>%
     unsuffix_and_regroup(old_groups) %>%
-    select(-.data$alias, -.data$alias_abcd)
+    select(-c("alias", "alias_abcd"))
 
   tmp <- tempfile()
   utils::write.csv(out, tmp, row.names = FALSE)

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -261,7 +261,7 @@ empty_loanbook_tibble <- function(loanbook, old_groups) {
 
   out <- named_tibble(names = minimum_names_of_match_name(loanbook)) %>%
     unsuffix_and_regroup(old_groups) %>%
-    select(-c("alias", "alias_abcd"))
+    select(-all_of(c("alias", "alias_abcd")))
 
   tmp <- tempfile()
   utils::write.csv(out, tmp, row.names = FALSE)

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -181,7 +181,7 @@ match_name_impl <- function(loanbook,
     return(empty_loanbook_tibble(loanbook, old_groups))
   }
 
-  l <- rename(prep_lbk, alias_lbk = .data$alias)
+  l <- rename(prep_lbk, alias_lbk = "alias")
   setDT(l)
   matched <- a[l, on = "alias_lbk", nomatch = 0]
   matched <- matched[,
@@ -287,12 +287,12 @@ expand_alias <- function(loanbook, abcd) {
 nest_by <- function(.data, ..., .key = "data") {
   grouped <- dplyr::group_by(.data, ...)
   nested <- tidyr::nest(grouped)
-  dplyr::rename(nested, !!.key := .data$data)
+  dplyr::rename(nested, !!.key := "data")
 }
 
 unsuffix_and_regroup <- function(data, old_groups) {
   data %>%
-    rename(alias = .data$alias_lbk) %>%
+    rename(alias = "alias_lbk") %>%
     group_by(!!!old_groups)
 }
 

--- a/R/prioritize.R
+++ b/R/prioritize.R
@@ -110,7 +110,7 @@ has_zero_rows <- function(data) {
 check_duplicated_score1 <- function(data) {
   score_1 <- filter(data, .data$score == 1)
   # The only important side effect of this function if to abort duplicated rows
-  loan_level <- suppressMessages(select(score_1, .data$id_loan, .data$level))
+  loan_level <- suppressMessages(select(score_1, all_of(c("id_loan", "level"))))
   is_duplicated <- duplicated(loan_level)
 
   if (!any(is_duplicated)) {

--- a/R/prioritize.R
+++ b/R/prioritize.R
@@ -81,7 +81,7 @@ prioritize <- function(data, priority = NULL) {
       )
     )
 
-    data <- dplyr::rename(data, sector_abcd = .data$sector_ald)
+    data <- dplyr::rename(data, sector_abcd = "sector_ald")
   }
 
   data %>%

--- a/R/restructure_abcd.R
+++ b/R/restructure_abcd.R
@@ -60,12 +60,12 @@ restructure_loanbook <- function(data, overwrite = NULL) {
 
   out <- may_add_sector_and_borderline(data)
   out <- select(
-    out, .data$rowid, all_of_(important_columns), .data$sector, .data$borderline
+    out, all_of(c("rowid", important_columns, "sector", "borderline"))
   )
   out <- identify_loans_by_level(out)
   out <- identify_loans_by_name(out)
   out <- mutate(out, source = "loanbook")
-  out <- select(out, .data$rowid, prep_lbk_cols())
+  out <- select(out, all_of(c("rowid", prep_lbk_cols())))
   out <- distinct(out)
   out <- may_overwrite_name_and_sector(out, overwrite = overwrite)
   out <- add_alias(out)

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -448,7 +448,7 @@ test_that("works with UP266", {
   prefix <- paste0(prefix, collapse = "|")
 
   expect_snapshot_value(
-    select(out, .data$id_2dii, matches(prefix)),
+    select(out, all_of("id_2dii"), matches(prefix)),
     style = "json2"
     )
 })

--- a/vignettes/r2dii-match.Rmd
+++ b/vignettes/r2dii-match.Rmd
@@ -139,11 +139,11 @@ The validated dataset may have multiple matches per loan. Consider the case wher
 # Pretend we validated the matched dataset
 valid_matches <- matched
 
-some_interesting_columns <- vars(id_2dii, level, score)
+some_interesting_columns <- c("id_2dii", "level", "score")
 
 valid_matches %>%
   prioritize() %>%
-  select(!!!some_interesting_columns)
+  select(all_of(some_interesting_columns))
 ```
 
 By default, highest priority refers to the most granular match (`direct_loantaker`). The default priority is set internally via `prioritize_levels()`.
@@ -157,5 +157,5 @@ You may use a different priority. One way to do that is to pass a function to `p
 ```{r}
 matched %>%
   prioritize(priority = rev) %>%
-  select(!!!some_interesting_columns)
+  select(all_of(some_interesting_columns))
 ```


### PR DESCRIPTION
Relates to https://github.com/2DegreesInvesting/r2dii.analysis/pull/1
Closes #417
