### PR TITLE
Increment version number to 0.1.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: r2dii.match
 Title: Tools to Match Corporate Lending Portfolios with Climate Data
-Version: 0.1.1.9000
+Version: 0.1.3
 Authors@R: 
     c(person(given = "Jackson",
              family = "Hoffart",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# r2dii.match (development version)
+# r2dii.match 0.1.3
+
+# r2dii.match 0.1.2
 
 * `r2dii.match` has transferred to a new organization 
 https://github.com/RMI-PACTA/. 


### PR DESCRIPTION
I messed up somehow and incremented the version number twice (oops), but 0.1.3 is the version on CRAN, so we're sticking with that. 