### PR TITLE
`to_alias()` now sanitizes string before calling `tolower()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # r2dii.match (development version)
 
-* `to_lower` can now handle strange encodings without error (#425, @kalashsinghal @Tilmon).
+* `to_alias` can now handle strange encodings without error (#425, @kalashsinghal @Tilmon).
 
 # r2dii.match 0.1.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # r2dii.match (development version)
 
+* `to_lower` can now handle strange encodings without error (#425, @kalashsinghal @Tilmon).
+
 # r2dii.match 0.1.3
 
 # r2dii.match 0.1.2

--- a/R/to_alias.R
+++ b/R/to_alias.R
@@ -65,12 +65,15 @@ to_alias <- function(x,
                      from_to = NULL,
                      ownership = NULL,
                      remove_ownership = FALSE) {
-  # lowercase
-  out <- tolower(x)
+
+  out <- x
 
   # base latin characters
   out <- stringi::stri_trans_general(out, "any-latin")
   out <- stringi::stri_trans_general(out, "latin-ascii")
+
+  # lowercase
+  out <- tolower(out)
 
   # symbols
   out <- reduce(get_sym_replace(), replace_abbrev, fixed = TRUE, .init = out)

--- a/tests/testthat/test-to_alias.R
+++ b/tests/testthat/test-to_alias.R
@@ -262,3 +262,10 @@ test_that("get_ownership_type() is equal to its legacy in pacta", {
     character(0)
   )
 })
+
+test_that("to_alias() handles string encoding before calling to_lower()", {
+  x <- "o_\xfc_dd"
+
+  expect_equal(to_alias(x, "odd"))
+
+})

--- a/tests/testthat/test-to_alias.R
+++ b/tests/testthat/test-to_alias.R
@@ -263,7 +263,8 @@ test_that("get_ownership_type() is equal to its legacy in pacta", {
   )
 })
 
-test_that("to_alias() handles string encoding before calling to_lower()", {
+test_that("to_alias() handles string encoding before calling to_lower(),
+          (#425, @kalashsinghal and @Tilmon)", {
   x <- "o_\xfc_dd"
 
   expect_equal(to_alias(x), "odd")

--- a/tests/testthat/test-to_alias.R
+++ b/tests/testthat/test-to_alias.R
@@ -266,6 +266,6 @@ test_that("get_ownership_type() is equal to its legacy in pacta", {
 test_that("to_alias() handles string encoding before calling to_lower()", {
   x <- "o_\xfc_dd"
 
-  expect_equal(to_alias(x, "odd"))
+  expect_equal(to_alias(x), "odd")
 
 })


### PR DESCRIPTION
Thanks @kalashsinghal, @Tilmon and @maurolepore for flagging this! And apologies for the delay on the solution. 

Closes #425 