### PR TITLE
Fix encoding unit test

### DIFF
--- a/tests/testthat/test-to_alias.R
+++ b/tests/testthat/test-to_alias.R
@@ -265,8 +265,8 @@ test_that("get_ownership_type() is equal to its legacy in pacta", {
 
 test_that("to_alias() handles string encoding before calling to_lower(),
           (#425, @kalashsinghal and @Tilmon)", {
-  x <- "o_\xfc_dd"
+  x <- `Encoding<-`("o\xfcdd", "latin1")
 
-  expect_equal(to_alias(x), "odd")
+  expect_equal(to_alias(x), "oudd")
 
 })


### PR DESCRIPTION
Thanks @cjyetman the solution you suggested worked perfectly. 
It was just a poorly-formatted unit test as @AlexAxthelm suggested.

Closes #436 