### PR TITLE
feat: `match_name` gains `join_id` col, allowing for an initial matching override based on some unique ID column

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # r2dii.match (development version)
 
+* `match_name` gains argument `join_id` allowing an optional perfect join based on a mutual ID column between `loanbook` and `abcd` inputs, prior to attempting fuzzy matching (#135).
+
 # r2dii.match 0.1.4
 
 * `to_alias` can now handle strange encodings without error (#425, @kalashsinghal @Tilmon).

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -164,16 +164,26 @@ match_name <- function(loanbook,
 
     prep_abcd <- dplyr::distinct(prep_abcd)
 
-    join_matched <- dplyr::inner_join(loanbook, prep_abcd, by = join_id)
+    prep_lbk <- may_add_sector_and_borderline(loanbook)
+    prep_lbk <- distinct(prep_lbk)
 
-    join_matched <- dplyr::mutate(
-      join_matched,
-      score = 1,
-      source = "id joined"
+    join_matched <- dplyr::inner_join(
+      prep_lbk,
+      prep_abcd,
+      by = join_id,
+      na_matches = "never"
       )
 
     join_by_list <- as_join_by(join_id)
     loanbook_join_id <- join_by_list[[1]]
+
+    join_matched <- dplyr::mutate(
+      join_matched,
+      score = 1,
+      source = "id joined",
+      level = loanbook_join_id,
+      name = .data[["name_abcd"]]
+    )
 
     loanbook <- dplyr::filter(
       loanbook,

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -129,7 +129,7 @@ match_name <- function(loanbook,
     abcd <- ald
   }
 
-  prep_abcd <- restructure_abcd(abcd)
+  prep_abcd <- restructure_abcd(abcd, join_id)
 
   if (!is.null(join_id)) {
     check_join_id(join_id, loanbook, prep_abcd)

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -137,31 +137,33 @@ match_name <- function(loanbook,
     join_matched <- dplyr::inner_join(
       loanbook, prep_abcd, by = join_id
       )
-    join_matched <- dplyr::mutate(
-      join_matched,
-      !!join_id := NULL,
-      score = 1
-      )
+
+    join_matched <- dplyr::mutate(join_matched, score = 1)
 
     loanbook <- dplyr::filter(
-      loanbook, !.data[[join_id]] %in% join_matched[[join_id]]
-      )
+      loanbook,
+      !.data[[join_id]] %in% join_matched[[join_id]]
+    )
   }
 
-  out <- match_name_impl(
-    loanbook = loanbook,
-    prep_abcd = prep_abcd,
-    by_sector = by_sector,
-    min_score = min_score,
-    method = method,
-    p = p,
-    overwrite = overwrite,
-    ...
-  )
+  if (nrow(loanbook) != 0) {
+    fuzzy_matched <- match_name_impl(
+      loanbook = loanbook,
+      prep_abcd = prep_abcd,
+      by_sector = by_sector,
+      min_score = min_score,
+      method = method,
+      p = p,
+      overwrite = overwrite,
+      ...
+    )
+  } else {
+    fuzzy_matched <- tibble()
+  }
 
-  if (nrow(out) != 0 && exists("join_matched")) {
-    out <- dplyr::bind_rows(join_matched, out)
-  } else if (nrow(out) == 0 && exists("join_matched")) {
+  if (exists("join_matched")) {
+    out <- dplyr::bind_rows(join_matched, fuzzy_matched)
+  } else if (nrow(fuzzy_matched) == 0 && exists("join_matched")) {
     out <- join_matched
   }
 

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -31,9 +31,10 @@
 #'   only `sector`, the value in the `name` column should be `NA` and
 #'   vice-versa. This file can be used to manually match loanbook companies to
 #'   abcd.
-#' @param join_id A character string naming an ID column used to left join
-#'   `abcd` to the `loanbook` (e.g. "lei"). ID column must be present, as named,
-#'   in both input datasets.
+#' @param join_id A join specification passe to [dplyr::inner_join()]. If a
+#'   character string, it assumes identical join columns between `loanbook` and
+#'   `abcd`. If a named list, uses the name as the join column of `loanbook` and
+#'   the value as the join column of `abcd`.
 #' @param ... Arguments passed on to [stringdist::stringsim()].
 #' @param ald `r lifecycle::badge('superseded')` `ald` has been superseded by
 #'   `abcd`.

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -463,7 +463,7 @@ as_join_by <- function(x) {
 
   if (rlang::is_list(x)) {
     if (length(x) != 1L) {
-      rlang::abort("`join_id` must be a list of length 1.")
+      rlang::abort("`join_id` must be a vector of length 1.")
     }
     x_name <- names(x) %||% x
     y_name <- unname(x)
@@ -474,7 +474,7 @@ as_join_by <- function(x) {
     # If x partially named, assume unnamed are the same in both tables
     x_name[x_name == ""] <- y_name[x_name == ""]
   } else {
-    rlang::abort("`by` must be a list or a character vector.")
+    rlang::abort("`by` must be a string or a character vector.")
   }
 
   if (!rlang::is_character(x_name)) {

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -444,14 +444,14 @@ check_join_id <- function(join_id, loanbook, abcd) {
     rlang::abort(
       "join_id_not_in_loanbook",
       message = glue(
-        "The join_id `{join_id}` must be present in both `loanbook` and `abcd`. It's not present in `loanbook`."
+        "The join_id `{join_id_list[[1]]}` must be present in `loanbook` input."
       )
     )
   } else if (!rlang::has_name(abcd, join_id_list[[2]])) {
     rlang::abort(
       "join_id_not_in_abcd",
       message = glue(
-        "The join_id `{join_id}` must be present in both `loanbook` and `abcd`. It's not present in `abcd`."
+        "The join_id `{join_id_list[[2]]}` must be present in `abcd` input."
       )
     )
   }

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -33,7 +33,7 @@
 #'   abcd.
 #' @param join_id A join specification passed to [dplyr::inner_join()]. If a
 #'   character string, it assumes identical join columns between `loanbook` and
-#'   `abcd`. If a named list, uses the name as the join column of `loanbook` and
+#'   `abcd`. If a named character vector, it uses the name as the join column of `loanbook` and
 #'   the value as the join column of `abcd`.
 #' @param ... Arguments passed on to [stringdist::stringsim()].
 #' @param ald `r lifecycle::badge('superseded')` `ald` has been superseded by

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -140,9 +140,12 @@ match_name <- function(loanbook,
 
     join_matched <- dplyr::mutate(join_matched, score = 1)
 
+    join_by_list <- as_join_by(join_id)
+    loanbook_join_id <- join_by_list[[1]]
+
     loanbook <- dplyr::filter(
       loanbook,
-      !.data[[join_id]] %in% join_matched[[join_id]]
+      !.data[[loanbook_join_id]] %in% join_matched[[loanbook_join_id]]
     )
   }
 
@@ -165,6 +168,8 @@ match_name <- function(loanbook,
     out <- dplyr::bind_rows(join_matched, fuzzy_matched)
   } else if (nrow(fuzzy_matched) == 0 && exists("join_matched")) {
     out <- join_matched
+  } else {
+    out <- fuzzy_matched
   }
 
   if (identical(nrow(out), 0L)) {
@@ -389,16 +394,17 @@ names_added_by_match_name <- function() {
 }
 
 check_join_id <- function(join_id, loanbook, abcd) {
-  stopifnot(is.character(join_id))
 
-  if (!rlang::has_name(loanbook, join_id)) {
+  join_id_list <- as_join_by(join_id)
+
+  if (!rlang::has_name(loanbook, join_id_list[[1]])) {
     rlang::abort(
       "join_id_not_in_loanbook",
       message = glue(
         "The join_id `{join_id}` must be present in both `loanbook` and `abcd`. It's not present in `loanbook`."
       )
     )
-  } else if (!rlang::has_name(abcd, join_id)) {
+  } else if (!rlang::has_name(abcd, join_id_list[[2]])) {
     rlang::abort(
       "join_id_not_in_abcd",
       message = glue(

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -409,3 +409,35 @@ check_join_id <- function(join_id, loanbook, abcd) {
 
   invisible(join_id)
 }
+
+as_join_by <- function(x) {
+
+  if (rlang::is_list(x)) {
+    if (length(x) != 1L) {
+      rlang::abort("`join_id` must be a list of length 1.")
+    }
+    x_name <- names(x) %||% x
+    y_name <- unname(x)
+  } else if (rlang::is_character(x)) {
+    x_name <- names(x) %||% x
+    y_name <- unname(x)
+
+    # If x partially named, assume unnamed are the same in both tables
+    x_name[x_name == ""] <- y_name[x_name == ""]
+  } else {
+    rlang::abort("`by` must be a list or a character vector.")
+  }
+
+  if (!rlang::is_character(x_name)) {
+    rlang::abort("`by$x` must evaluate to a character vector.")
+  }
+  if (!rlang::is_character(y_name)) {
+    rlang::abort("`by$y` must evaluate to a character vector.")
+  }
+
+  c(x_name, y_name)
+}
+
+`%||%` <- function(x, y) {
+  if (is.null(x)) y else x
+}

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -87,6 +87,25 @@
 #'   code_system = "XYZ"
 #' )
 #'
+#' # match on LEI
+#' loanbook <- tibble(
+#'   sector_classification_system = "XYZ",
+#'   sector_classification_direct_loantaker = "D35.11",
+#'   id_ultimate_parent = "UP15",
+#'   name_ultimate_parent = "Won't fuzzy match",
+#'   id_direct_loantaker = "C294",
+#'   name_direct_loantaker = "Won't fuzzy match",
+#'   lei_direct_loantaker = "LEI123"
+#' )
+#'
+#' abcd <- tibble(
+#'   name_company = "alpine knits india pvt. limited",
+#'   sector = "power",
+#'   lei = "LEI123"
+#' )
+#'
+#' match_name(loanbook, abcd, join_by = c(lei_direct_loantaker = "lei"))
+#'
 #' restore <- options(r2dii.match.sector_classifications = your_classifications)
 #'
 #' loanbook <- tibble(

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -31,7 +31,7 @@
 #'   only `sector`, the value in the `name` column should be `NA` and
 #'   vice-versa. This file can be used to manually match loanbook companies to
 #'   abcd.
-#' @param join_id A join specification passe to [dplyr::inner_join()]. If a
+#' @param join_id A join specification passed to [dplyr::inner_join()]. If a
 #'   character string, it assumes identical join columns between `loanbook` and
 #'   `abcd`. If a named list, uses the name as the join column of `loanbook` and
 #'   the value as the join column of `abcd`.

--- a/R/restructure_abcd.R
+++ b/R/restructure_abcd.R
@@ -16,26 +16,15 @@
 #' @examples
 #' restructure_abcd(r2dii.data::abcd_demo)
 #' @noRd
-restructure_abcd <- function(data, join_id = NULL) {
+restructure_abcd <- function(data) {
   crucial_names <- c("name_company", "sector")
-  if (!is.null(join_id)) {
-    check_crucial_names(data, c(join_id, crucial_names))
+  check_crucial_names(data, crucial_names)
 
-    out <- dplyr::transmute(
-      data,
-      name = .data$name_company,
-      sector = tolower(.data$sector),
-      !!join_id := .data[[join_id]]
-    )
-  } else {
-    check_crucial_names(data, crucial_names)
-
-    out <- dplyr::transmute(
-      data,
-      name = .data$name_company,
-      sector = tolower(.data$sector)
-    )
-  }
+  out <- dplyr::transmute(
+    data,
+    name = .data$name_company,
+    sector = tolower(.data$sector)
+  )
 
   out <- distinct(out)
   add_alias(out)

--- a/R/restructure_abcd.R
+++ b/R/restructure_abcd.R
@@ -5,6 +5,8 @@
 #' from values in the `name_company` column.
 #'
 #' @param data A data frame. Should be an asset-level dataset.
+#' @param join_id (Optional) A string giving the name of an `ID` column to
+#'   preserve in the restructuring
 #'
 #' @seealso [r2dii.data::abcd_demo] `to_alias()`.
 #'
@@ -14,13 +16,27 @@
 #' @examples
 #' restructure_abcd(r2dii.data::abcd_demo)
 #' @noRd
-restructure_abcd <- function(data) {
-  check_crucial_names(data, c("name_company", "sector"))
+restructure_abcd <- function(data, join_id = NULL) {
+  crucial_names <- c("name_company", "sector")
+  if (!is.null(join_id)) {
+    check_crucial_names(data, c(join_id, crucial_names))
 
-  out <- dplyr::transmute(
-    data,
-    name = .data$name_company, sector = tolower(.data$sector)
-  )
+    out <- dplyr::transmute(
+      data,
+      name = .data$name_company,
+      sector = tolower(.data$sector),
+      !!join_id := .data[[join_id]]
+    )
+  } else {
+    check_crucial_names(data, crucial_names)
+
+    out <- dplyr::transmute(
+      data,
+      name = .data$name_company,
+      sector = tolower(.data$sector)
+    )
+  }
+
   out <- distinct(out)
   add_alias(out)
 }

--- a/man/match_name.Rd
+++ b/man/match_name.Rd
@@ -130,6 +130,25 @@ your_classifications <- tibble(
   code_system = "XYZ"
 )
 
+# match on LEI
+loanbook <- tibble(
+  sector_classification_system = "XYZ",
+  sector_classification_direct_loantaker = "D35.11",
+  id_ultimate_parent = "UP15",
+  name_ultimate_parent = "Won't fuzzy match",
+  id_direct_loantaker = "C294",
+  name_direct_loantaker = "Won't fuzzy match",
+  lei_direct_loantaker = "LEI123"
+)
+
+abcd <- tibble(
+  name_company = "alpine knits india pvt. limited",
+  sector = "power",
+  lei = "LEI123"
+)
+
+match_name(loanbook, abcd, join_by = c(lei_direct_loantaker = "lei"))
+
 restore <- options(r2dii.match.sector_classifications = your_classifications)
 
 loanbook <- tibble(

--- a/man/match_name.Rd
+++ b/man/match_name.Rd
@@ -40,7 +40,7 @@ only \code{sector}, the value in the \code{name} column should be \code{NA} and
 vice-versa. This file can be used to manually match loanbook companies to
 abcd.}
 
-\item{join_id}{A join specification passe to \code{\link[dplyr:mutate-joins]{dplyr::inner_join()}}. If a
+\item{join_id}{A join specification passed to \code{\link[dplyr:mutate-joins]{dplyr::inner_join()}}. If a
 character string, it assumes identical join columns between \code{loanbook} and
 \code{abcd}. If a named list, uses the name as the join column of \code{loanbook} and
 the value as the join column of \code{abcd}.}

--- a/man/match_name.Rd
+++ b/man/match_name.Rd
@@ -40,9 +40,10 @@ only \code{sector}, the value in the \code{name} column should be \code{NA} and
 vice-versa. This file can be used to manually match loanbook companies to
 abcd.}
 
-\item{join_id}{A character string naming an ID column used to left join
-\code{abcd} to the \code{loanbook} (e.g. "lei"). ID column must be present, as named,
-in both input datasets.}
+\item{join_id}{A join specification passe to \code{\link[dplyr:mutate-joins]{dplyr::inner_join()}}. If a
+character string, it assumes identical join columns between \code{loanbook} and
+\code{abcd}. If a named list, uses the name as the join column of \code{loanbook} and
+the value as the join column of \code{abcd}.}
 
 \item{ald}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}} \code{ald} has been superseded by
 \code{abcd}.}

--- a/man/match_name.Rd
+++ b/man/match_name.Rd
@@ -42,7 +42,7 @@ abcd.}
 
 \item{join_id}{A join specification passed to \code{\link[dplyr:mutate-joins]{dplyr::inner_join()}}. If a
 character string, it assumes identical join columns between \code{loanbook} and
-\code{abcd}. If a named list, uses the name as the join column of \code{loanbook} and
+\code{abcd}. If a named character vector, it uses the name as the join column of \code{loanbook} and
 the value as the join column of \code{abcd}.}
 
 \item{ald}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}} \code{ald} has been superseded by

--- a/man/match_name.Rd
+++ b/man/match_name.Rd
@@ -12,6 +12,7 @@ match_name(
   method = "jw",
   p = 0.1,
   overwrite = NULL,
+  join_id = NULL,
   ald = deprecated(),
   ...
 )
@@ -38,6 +39,10 @@ columns of a particular direct loantaker or ultimate parent. To overwrite
 only \code{sector}, the value in the \code{name} column should be \code{NA} and
 vice-versa. This file can be used to manually match loanbook companies to
 abcd.}
+
+\item{join_id}{A character string naming an ID column used to left join
+\code{abcd} to the \code{loanbook} (e.g. "lei"). ID column must be present, as named,
+in both input datasets.}
 
 \item{ald}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}} \code{ald} has been superseded by
 \code{abcd}.}

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -723,3 +723,36 @@ test_that("allows custom `sector_classifications` via options() (#354)", {
   expect_equal(nrow(out), 1L)
   options(old)
 })
+
+test_that("`join_id` optionally joins as expected (#135)", {
+
+  loanbook <- tibble(
+    sector_classification_system = "NACE",
+    sector_classification_direct_loantaker = "100", # this generally shouldn't match to anything
+    id_ultimate_parent = c("UP15", "UP16"),
+    name_ultimate_parent = c("Foo", "Bar"),
+    id_direct_loantaker = c("C294", "C295"),
+    name_direct_loantaker = "Baz",
+    id_col = c("LEI123", NA_character_)
+  )
+
+  abcd <- tibble(
+    name_company = "alpine knits india pvt. limited",
+    sector = "power",
+    id_col = "LEI123"
+  )
+
+  # expect no match here, the company names are completely different
+  expect_warning(match_name(loanbook, abcd, join_id = NULL), "no match")
+
+  # expect exactly one match here, based on input ID
+  out_with_join_id <- match_name(loanbook, abcd, join_id = "id_col")
+  expect_equal(nrow(out_with_join_id), 1L)
+
+  # should work for id_col with any name, e.g. `lei`
+  loanbook_lei <- rename(loanbook, lei = id_col)
+  abcd_lei <- rename(abcd, lei = id_col)
+  out_lei <- match_name(loanbook_lei, abcd_lei, join_id = "lei")
+  expect_equal(nrow(out_lei), 1L)
+
+})

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -782,7 +782,7 @@ test_that("with `join_id`, outputs data with loanbook join column (#135)", {
 
   expect_contains(names(out), "foo")
 
-  # with `join_id` as named list
+  # with `join_id` as a named vector
   out <- match_name(
     fake_lbk(foo_lbk = "1"),
     fake_abcd(foo_abcd = "1"),

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -842,6 +842,6 @@ test_that("with `join_id` and one ID match, one fuzzy match, outputs as expected
   out <- split(out, out$id_loan)
 
   expect_equal(out$L1$lei_direct_loantaker, "LEI123")
-  expect_equal(out$L2$name, "UP will fuzzy match")
+  expect_equal(out$L2$name_abcd, "UP will fuzzy match")
 
 })

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -814,7 +814,7 @@ test_that("with `join_id` and multiple matches, prefers ID (#135)", {
     join_id = c(lei_direct_loantaker = "lei")
   )
 
-  expect_equal(unique(out_with_join_id$lei_direct_loantaker), "LEI123")
+  expect_equal(unique(out$lei_direct_loantaker), "LEI123")
 
 })
 

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -725,7 +725,7 @@ test_that("allows custom `sector_classifications` via options() (#354)", {
 })
 
 test_that("with `join_id`, joins as expected (#135)", {
-
+  skip_if_r2dii_data_outdated()
   loanbook <- fake_lbk(
     name_direct_loantaker = "DL won't fuzzy match",
     name_ultimate_parent = "UP won't fuzzy match",
@@ -748,7 +748,7 @@ test_that("with `join_id`, joins as expected (#135)", {
 })
 
 test_that("with `join_id` accepts list input indicating different cols (#135)", {
-
+  skip_if_r2dii_data_outdated()
   loanbook <- fake_lbk(
     name_direct_loantaker = "DL won't fuzzy match",
     name_ultimate_parent = "UP won't fuzzy match",
@@ -772,7 +772,7 @@ test_that("with `join_id` accepts list input indicating different cols (#135)", 
 })
 
 test_that("with `join_id`, outputs data with loanbook join column (#135)", {
-
+  skip_if_r2dii_data_outdated()
   # with `join_id` as character
   out <- match_name(
     fake_lbk(foo = "1"),
@@ -794,7 +794,7 @@ test_that("with `join_id`, outputs data with loanbook join column (#135)", {
 })
 
 test_that("with `join_id` and multiple matches, prefers ID (#135)", {
-
+  skip_if_r2dii_data_outdated()
   # loanbook might match at UP
   loanbook <- fake_lbk(
     name_direct_loantaker = "DL won't fuzzy match",
@@ -819,8 +819,7 @@ test_that("with `join_id` and multiple matches, prefers ID (#135)", {
 })
 
 test_that("with `join_id` and one ID match, one fuzzy match, outputs as expected (#135)", {
-
-
+  skip_if_r2dii_data_outdated()
   loanbook <- fake_lbk(
     id_loan = c("L1", "L2"), # L1 should ID match, L2 should fuzzy match
     name_direct_loantaker = "DL won't fuzzy match",

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -724,7 +724,7 @@ test_that("allows custom `sector_classifications` via options() (#354)", {
   options(old)
 })
 
-test_that("`join_id` optionally joins as expected (#135)", {
+test_that("with `join_id`, joins as expected (#135)", {
 
   loanbook <- fake_lbk(
     name_direct_loantaker = "DL won't fuzzy match",

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -742,9 +742,12 @@ test_that("with `join_id`, joins as expected (#135)", {
   # expect exactly one match here, based on input ID
   out_with_join_id <- match_name(loanbook, abcd, join_id = "id_col")
   expect_equal(nrow(out_with_join_id), 1L)
+  expect_contains(names(out_with_join_id), "id_col")
+  expect_equal(unique(out_with_join_id$id_col), "LEI123")
+
 })
 
-test_that("with `join_id` accepts list input indicating different cols", {
+test_that("with `join_id` accepts list input indicating different cols (#135)", {
 
   loanbook <- fake_lbk(
     name_direct_loantaker = "DL won't fuzzy match",
@@ -763,6 +766,8 @@ test_that("with `join_id` accepts list input indicating different cols", {
     )
 
   expect_equal(nrow(out_with_join_id), 1L)
+  expect_contains(names(out_with_join_id), "lei_direct_loantaker")
+  expect_equal(unique(out_with_join_id$lei_direct_loantaker), "LEI123")
 
 })
 
@@ -785,5 +790,58 @@ test_that("with `join_id`, outputs data with loanbook join column (#135)", {
   )
 
   expect_contains(names(out), "foo_lbk")
+
+})
+
+test_that("with `join_id` and multiple matches, prefers ID (#135)", {
+
+  # loanbook might match at UP
+  loanbook <- fake_lbk(
+    name_direct_loantaker = "DL won't fuzzy match",
+    name_ultimate_parent = "UP will fuzzy match",
+    lei_direct_loantaker = "LEI123"
+  )
+
+  abcd <- fake_abcd(
+    lei = "LEI123",
+    name_company = "UP will fuzzy match"
+  )
+
+  # with `join_id` as named list
+  out <- match_name(
+    loanbook,
+    abcd,
+    join_id = c(lei_direct_loantaker = "lei")
+  )
+
+  expect_equal(unique(out_with_join_id$lei_direct_loantaker), "LEI123")
+
+})
+
+test_that("with `join_id` and one ID match, one fuzzy match, outputs as expected (#135)", {
+
+
+  loanbook <- fake_lbk(
+    id_loan = c("L1", "L2"), # L1 should ID match, L2 should fuzzy match
+    name_direct_loantaker = "DL won't fuzzy match",
+    name_ultimate_parent = c("UP won't fuzzy match", "UP will fuzzy match"),
+    lei_direct_loantaker = c("LEI123", NA_character_)
+  )
+
+  abcd <- fake_abcd(
+    name_company = c("a power company", "UP will fuzzy match"),
+    lei = c("LEI123", NA_character_)
+  )
+
+  out <- match_name(
+    loanbook,
+    abcd,
+    join_id = c(lei_direct_loantaker = "lei")
+  )
+
+  out <- split(out, out$id_loan)
+
+  expect_equal(out$L1$lei_direct_loantaker, "LEI123")
+  expect_equal(out$L2$name, "UP will fuzzy match")
 
 })

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -747,7 +747,7 @@ test_that("with `join_id`, joins as expected (#135)", {
 
 })
 
-test_that("with `join_id` accepts list input indicating different cols (#135)", {
+test_that("with `join_id` accepts named character vector input indicating different cols (#135)", {
   skip_if_r2dii_data_outdated()
   loanbook <- fake_lbk(
     name_direct_loantaker = "DL won't fuzzy match",

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -724,6 +724,8 @@ test_that("allows custom `sector_classifications` via options() (#354)", {
   options(old)
 })
 
+
+
 test_that("`join_id` optionally joins as expected (#135)", {
 
   loanbook <- tibble(
@@ -754,5 +756,17 @@ test_that("`join_id` optionally joins as expected (#135)", {
   abcd_lei <- rename(abcd, lei = id_col)
   out_lei <- match_name(loanbook_lei, abcd_lei, join_id = "lei")
   expect_equal(nrow(out_lei), 1L)
+
+})
+
+test_that("with `join_id`, outputs data with join column (#135)", {
+
+  out <- match_name(
+    fake_lbk(foo = "1"),
+    fake_abcd(foo = "1"),
+    join_id = "foo"
+    )
+
+  expect_contains(names(out), "foo")
 
 })

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -807,7 +807,7 @@ test_that("with `join_id` and multiple matches, prefers ID (#135)", {
     name_company = "UP will fuzzy match"
   )
 
-  # with `join_id` as named list
+  # with `join_id` as named vector
   out <- match_name(
     loanbook,
     abcd,

--- a/tests/testthat/test-prioritize.R
+++ b/tests/testthat/test-prioritize.R
@@ -236,7 +236,8 @@ test_that("with 0-row input returns 0-row input", {
   expect_no_error(prioritize(zero_row))
 })
 
-test_that("with `join_id`, outputs as expected", {
+test_that("with `match_name` with `join_id`, outputs as expected (#135)", {
+  skip_if_r2dii_data_outdated()
   lbk <- fake_lbk(id_loan = "L1", id_col = "1")
   abcd <- fake_abcd(id_col = "1")
   matched <- match_name(lbk, abcd, join_id = "id_col")

--- a/tests/testthat/test-prioritize.R
+++ b/tests/testthat/test-prioritize.R
@@ -235,3 +235,12 @@ test_that("with 0-row input returns 0-row input", {
 
   expect_no_error(prioritize(zero_row))
 })
+
+test_that("with `join_id`, outputs as expected", {
+  lbk <- fake_lbk(id_loan = "L1", id_col = "1")
+  abcd <- fake_abcd(id_col = "1")
+  matched <- match_name(lbk, abcd, join_id = "id_col")
+
+  out <- prioritize(matched)
+  expect_equal(nrow(out), 1L)
+})


### PR DESCRIPTION
This ID column could be, for example, `lei` or `isin`. 

Some open questions I have before marking this as ready for review: 

- [x] Currently the ID column must be identical between each dataset, but I think perhaps it might be better to allow for a named argument, with one name indicating the `loanbook` column name (e.g. `lei_direct_loantaker`), and another column indicating the `abcd` column name (e.g. `lei`) 
- [x] Currently the functionality only allows for a SINGLE join column. e.g. there is no way to give a handful of columns, and join by priority (ISIN -> LEI -> etc.)
- [x] Definitely needs way more tests. Especially, there should be some input checks that assess that there aren't multiple joins per company. I can imagine a `loanbook` with multiple identical LEIs, and an `abcd` with several `name_company` values that have the same LEI. Need to consider what to do in that case

See reprex:
``` r
library(tibble)
library(r2dii.match)

loanbook <- tibble(
  sector_classification_system = "NACE",
  sector_classification_direct_loantaker = "100", # this generally shouldn't match to anything
  id_ultimate_parent = c("UP15", "UP16"),
  name_ultimate_parent = c("Foo", "Bar"),
  id_direct_loantaker = c("C294", "C295"),
  name_direct_loantaker = "Yuamen Xinneng Thermal Power Co Ltd",
  lei = c("LEI123", NA_character_)
)

abcd <- tibble(
  name_company = "alpine knits india pvt. limited",
  sector = "power",
  lei = "LEI123"
)

# no match found, as expected
# outputs "message" that no match was found by fuzzy matching, and warning that no match was found overall
match_name(loanbook, abcd, join_id = NULL)
#> Found no match via fuzzy matching.
#> Warning: Found no match.
#> # A tibble: 0 × 16
#> # ℹ 16 variables: sector_classification_system <chr>,
#> #   sector_classification_direct_loantaker <chr>, id_ultimate_parent <chr>,
#> #   name_ultimate_parent <chr>, id_direct_loantaker <chr>,
#> #   name_direct_loantaker <chr>, lei <chr>, id_2dii <lgl>, level <lgl>,
#> #   sector <lgl>, sector_abcd <lgl>, name <lgl>, name_abcd <lgl>, score <lgl>,
#> #   source <lgl>, borderline <lgl>

# no match found via fuzzy matching, as expected
# outputs "message" that no match was found by fuzzy matching, but successfully outputs the joined match
match_name(loanbook, abcd, join_id = "lei")
#> Found no match via fuzzy matching.
#> # A tibble: 1 × 10
#>   sector_classification_system sector_classification_direct…¹ id_ultimate_parent
#>   <chr>                        <chr>                          <chr>             
#> 1 NACE                         100                            UP15              
#> # ℹ abbreviated name: ¹​sector_classification_direct_loantaker
#> # ℹ 7 more variables: name_ultimate_parent <chr>, id_direct_loantaker <chr>,
#> #   name_direct_loantaker <chr>, name <chr>, sector <chr>, alias <chr>,
#> #   score <dbl>
```

<sup>Created on 2024-03-07 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

Closes #135
