### PR TITLE
upkeep: complete the deprecation of`ald` in favour of `abcd`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # r2dii.match (development version)
 
+* Complete deprecation of `ald` in favour of `abcd` (#399).
+
 * `match_name` gains argument `join_id` allowing an optional perfect join based on a mutual ID column between `loanbook` and `abcd` inputs, prior to attempting fuzzy matching (#135).
 
 # r2dii.match 0.1.4

--- a/R/imports.R
+++ b/R/imports.R
@@ -22,14 +22,12 @@ globalVariables(
     ".",
     ".data",
     "alias_abcd",
-    "alias_ald",
     "alias_lbk",
     "id_2dii",
     "pick",
     "rowid",
     "score",
     "sector",
-    "sector_abcd",
-    "sector_ald"
+    "sector_abcd"
   )
 )

--- a/R/match_name.R
+++ b/R/match_name.R
@@ -36,8 +36,6 @@
 #'   `abcd`. If a named character vector, it uses the name as the join column of `loanbook` and
 #'   the value as the join column of `abcd`.
 #' @param ... Arguments passed on to [stringdist::stringsim()].
-#' @param ald `r lifecycle::badge('superseded')` `ald` has been superseded by
-#'   `abcd`.
 #'
 #' @family main functions
 #'
@@ -135,19 +133,9 @@ match_name <- function(loanbook,
                        p = 0.1,
                        overwrite = NULL,
                        join_id = NULL,
-                       ald = deprecated(),
                        ...) {
   restore <- options(datatable.allow.cartesian = TRUE)
   on.exit(options(restore), add = TRUE)
-
-  if (lifecycle::is_present(ald)) {
-    lifecycle::deprecate_warn(
-      "0.1.0 (expected July 2022)",
-      "match_name(ald)",
-      "match_name(abcd)"
-      )
-    abcd <- ald
-  }
 
   if (!is.null(join_id)) {
     check_join_id(join_id, loanbook, abcd)

--- a/R/prioritize.R
+++ b/R/prioritize.R
@@ -61,29 +61,6 @@ prioritize <- function(data, priority = NULL) {
     return(data)
   }
 
-  if (all(c("sector_ald", "sector_abcd") %in% names(data))) {
-
-    rlang::abort(
-      "too_many_sectors",
-      message = glue(
-        "Column `sector_ald` is deprecated as of r2dii.match 0.1.0, please use
-        `sector_abcd` instead."
-      )
-    )
-
-  } else if ("sector_ald" %in% names(data)) {
-
-    rlang::warn(
-      "deprecated_name",
-      message = glue(
-        "Column `sector_ald` is deprecated as of r2dii.match 0.1.0, please use
-        `sector_abcd` instead."
-      )
-    )
-
-    data <- dplyr::rename(data, sector_abcd = "sector_ald")
-  }
-
   data %>%
     check_crucial_names(
       c("id_loan", "level", "score", "sector", "sector_abcd")

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -12,7 +12,6 @@ ORCID
 PACTA
 Winkler
 abcd
-ald
 cjyetman
 counterparties
 counterparty

--- a/man/match_name.Rd
+++ b/man/match_name.Rd
@@ -13,7 +13,6 @@ match_name(
   p = 0.1,
   overwrite = NULL,
   join_id = NULL,
-  ald = deprecated(),
   ...
 )
 }
@@ -44,9 +43,6 @@ abcd.}
 character string, it assumes identical join columns between \code{loanbook} and
 \code{abcd}. If a named character vector, it uses the name as the join column of \code{loanbook} and
 the value as the join column of \code{abcd}.}
-
-\item{ald}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}} \code{ald} has been superseded by
-\code{abcd}.}
 
 \item{...}{Arguments passed on to \code{\link[stringdist:stringsim]{stringdist::stringsim()}}.}
 }


### PR DESCRIPTION
We initiated this deprecation in [r2dii.match v0.1.0](https://github.com/RMI-PACTA/r2dii.match/releases/tag/v0.1.0)
Users have now had a long time and sufficient warning to update any of their references. 

Closes #399 