### PR TITLE
lifecycle: bump from maturing to stable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # r2dii.match (development version)
 
+* r2dii.match is now [stable](https://lifecycle.r-lib.org/articles/stages.html).
+
 # r2dii.match 0.2.0
 
 * Complete deprecation of `ald` in favour of `abcd` (#399).

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,6 +21,7 @@ knitr::opts_chunk$set(
 [![](https://cranlogs.r-pkg.org/badges/grand-total/r2dii.match)](https://CRAN.R-project.org/package=r2dii.match)
 [![Codecov test coverage](https://codecov.io/gh/RMI-PACTA/r2dii.match/branch/main/graph/badge.svg)](https://app.codecov.io/gh/RMI-PACTA/r2dii.match?branch=main)
 [![R-CMD-check](https://github.com/RMI-PACTA/r2dii.match/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/RMI-PACTA/r2dii.match/actions/workflows/R-CMD-check.yaml)
+[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 <!-- badges: end -->
 
 These tools implement in R a fundamental part of

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ status](https://www.r-pkg.org/badges/version/r2dii.match)](https://CRAN.R-projec
 [![Codecov test
 coverage](https://codecov.io/gh/RMI-PACTA/r2dii.match/branch/main/graph/badge.svg)](https://app.codecov.io/gh/RMI-PACTA/r2dii.match?branch=main)
 [![R-CMD-check](https://github.com/RMI-PACTA/r2dii.match/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/RMI-PACTA/r2dii.match/actions/workflows/R-CMD-check.yaml)
+[![Lifecycle:
+stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 <!-- badges: end -->
 
 These tools implement in R a fundamental part of the software PACTA


### PR DESCRIPTION
Relates to https://github.com/RMI-PACTA/workflow.factset/pull/68
The concept of "lifecycle maturing" is now deprecated. 

FYI @AlexAxthelm 