### PR TITLE
Use dev branch of action to integrate revdep checks

### DIFF
--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -19,11 +19,11 @@ name: R
 jobs:
   R-package:
     name: R Package Checks
-    uses: RMI-PACTA/actions/.github/workflows/R.yml@main
+    uses: RMI-PACTA/actions/.github/workflows/R.yml@ci/95-r-rev-dep-check
 
   dev-r-cmd-check:
     name: R CMD Check (dev versions)
-    uses: RMI-PACTA/actions/.github/workflows/R-CMD-check.yml@main
+    uses: RMI-PACTA/actions/.github/workflows/R.yml@ci/95-r-rev-dep-check
     with:
       upgrade-packages: 'TRUE'
       cache-version: 'dev'

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -20,6 +20,14 @@ jobs:
   R-package:
     name: R Package Checks
     uses: RMI-PACTA/actions/.github/workflows/R.yml@ci/95-r-rev-dep-check
+    with:
+      revdeps: |
+          [
+            {"pkg": "RMI-PACTA/r2dii.analysis"},
+            {"pkg": "RMI-PACTA/r2dii.plot"},
+            {"pkg": "r2dii.analysis"},
+            {"pkg": "r2dii.plot"}
+          ]
 
   dev-r-cmd-check:
     name: R CMD Check (dev versions)

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -19,7 +19,7 @@ name: R
 jobs:
   R-package:
     name: R Package Checks
-    uses: RMI-PACTA/actions/.github/workflows/R.yml@ci/95-r-rev-dep-check
+    uses: RMI-PACTA/actions/.github/workflows/R.yml@main
     with:
       revdeps: |
           [
@@ -31,7 +31,7 @@ jobs:
 
   dev-r-cmd-check:
     name: R CMD Check (dev versions)
-    uses: RMI-PACTA/actions/.github/workflows/R-CMD-check.yml@ci/95-r-rev-dep-check
+    uses: RMI-PACTA/actions/.github/workflows/R-CMD-check.yml@main
     with:
       upgrade-packages: 'TRUE'
       cache-version: 'dev'

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -23,7 +23,7 @@ jobs:
 
   dev-r-cmd-check:
     name: R CMD Check (dev versions)
-    uses: RMI-PACTA/actions/.github/workflows/R.yml@ci/95-r-rev-dep-check
+    uses: RMI-PACTA/actions/.github/workflows/R-CMD-check.yml@ci/95-r-rev-dep-check
     with:
       upgrade-packages: 'TRUE'
       cache-version: 'dev'


### PR DESCRIPTION
Add reverse dependency checks from both GitHub and cran-like package sources

Relates to https://github.com/RMI-PACTA/r2dii.data/pull/396

- [ ] Depends on https://github.com/RMI-PACTA/actions/pull/96