### PR TITLE
use pkgdown defaults where possible and modernize custom navbar specs

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -16,38 +16,36 @@ home:
   - text: Learn more
     href: https://www.transitionmonitor.com/
 navbar:
-  type: default
-  left:
-  - text: Get started
-    href: articles/r2dii-match.html
-  - text: Reference
-    href: reference/index.html
-  - text: Articles
-    menu:
-    - text: Calculating Matching Coverage
-      href: articles/matching-coverage.html
-    - text: Using `match_name()` with large loanbooks
-      href: articles/chunk-your-data.html
-  - text: News
-    menu:
-    - text: r2dii blog posts
-      href: https://rmi-pacta.github.io/#category:r2dii
-    - text: '----------------------'
-    - text: Change log
-      href: news/index.html
-  right:
-  - text: Packages
-    menu:
-    - text: r2dii.data
-      href: https://rmi-pacta.github.io/r2dii.data
-    - text: r2dii.match
-      href: https://rmi-pacta.github.io/r2dii.match
-    - text: r2dii.analysis
-      href: https://rmi-pacta.github.io/r2dii.analysis
-    - text: r2dii.plot
-      href: https://rmi-pacta.github.io/r2dii.plot
-  - icon: fa-github
-    href: https://github.com/RMI-PACTA/r2dii.match
+  structure:
+    left:  [intro, reference, articles, news]
+    right: [search, packages, github]
+  components:
+    articles:
+      text: Articles
+      menu:
+      - text: Calculating Matching Coverage
+        href: articles/matching-coverage.html
+      - text: Using `match_name()` with large loanbooks
+        href: articles/chunk-your-data.html
+    news:
+      text: News
+      menu:
+      - text: r2dii blog posts
+        href: https://rmi-pacta.github.io/#category:r2dii
+      - text: '----------------------'
+      - text: Change log
+        href: news/index.html
+    packages:
+      text: Packages
+      menu:
+      - text: r2dii.data
+        href: https://rmi-pacta.github.io/r2dii.data
+      - text: r2dii.match
+        href: https://rmi-pacta.github.io/r2dii.match
+      - text: r2dii.analysis
+        href: https://rmi-pacta.github.io/r2dii.analysis
+      - text: r2dii.plot
+        href: https://rmi-pacta.github.io/r2dii.plot
 reference:
 - title: Main functions
   contents: has_concept("main functions")


### PR DESCRIPTION
prompted by trying to fix the navbar text showing in black instead of white as with the RMI template (which this does seem to fix)

This pkgdown config must have been written before pkgdwon used the modern `navbar > structure` and `navbar > components` properties to customize the navbar. Additionally, pkgdown (now?) has default navbar items that can be used/placed in the structure without having to explicitly define them in the components section, which this leverages to reduce complexity and allow things to be automatically defined.

The "Articles" menu was explicitly defined only pointing to two specific vignettes (ignoring any others). I maintained this behavior, but I suggest that this may not be ideal.

The "News" menu was customized to include a link to the "r2dii blog" which is still just a template with no actual content. I maintained this behavior, but I suggest that this may not be ideal.