### PR TITLE
remove explicit authors config from  _pkgdown.yml

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,13 +4,6 @@ development:
 template:
   package: pacta.pkgdown.rmitemplate
 url: https://rmi-pacta.github.io/r2dii.match
-authors:
-  Jackson Hoffart:
-    href: https://github.com/jdhoffa/
-  Mauro Lepore:
-    href: https://github.com/maurolepore/
-  Rocky Mountain Institute:
-    href: https://rmi.org/
 home:
   links:
   - text: Learn more


### PR DESCRIPTION
pkgdown will automatically pull the authors from the DESCRIPTION and automatically determine their role, which seems more ideal... unless it's desirable to explicitly list some contributors and ignore the rest