### PR TITLE
track v4, not v4.x.x, versions of github-pages-deploy action

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.6.4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           clean: ${{ github.event_name == 'workflow_dispatch' && inputs.clean || false }}
           branch: gh-pages


### PR DESCRIPTION
The [github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action) appears to point `vX` tags to whatever the latest `vX.y.z` tag is (e.g. [v4 currently points to the same commit that v4.6.8 does](https://github.com/JamesIves/github-pages-deploy-action/tags)), which means we should be able to use `uses: JamesIves/github-pages-deploy-action@v4` and always get the latest v4.x.y that's available without having to merge dependabot update PRs every few weeks.