### PR TITLE
thread limit for testthat.R

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,5 @@
 library(testthat)
 library(r2dii.match)
 
+Sys.setenv("OMP_THREAD_LIMIT" = 2)
 test_check("r2dii.match")


### PR DESCRIPTION
relates to #522 

CRAN submission returned the following issue on Debian: https://forum.posit.co/t/cran-incoming-checks-cpu-time-xx-times-elapsed-time/197049

* testthat.R gains thread limit