### PR TITLE
add tests for `data_dictionary`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,10 +68,12 @@ Imports:
     tidyselect,
     utils
 Suggests: 
+    cli,
     covr,
     rmarkdown,
     spelling,
-    testthat (>= 2.1.0)
+    testthat (>= 2.1.0),
+    waldo
 Config/testthat/edition: 3
 Config/Needs/website: rmi-pacta/pacta.pkgdown.rmitemplate
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,6 +70,7 @@ Imports:
 Suggests: 
     cli,
     covr,
+    readr,
     rmarkdown,
     spelling,
     testthat (>= 2.1.0),

--- a/data-raw/build_data_dictionary.R
+++ b/data-raw/build_data_dictionary.R
@@ -4,6 +4,6 @@ library(usethis)
 paths <- list.files("data-raw/data_dictionary", full.names = TRUE)
 
 out <- readr::read_csv(file = paths, show_col_types = FALSE)
-data_dictionary <- out[order(out$dataset, out$column), , drop = FALSE]
+data_dictionary <- out[order(out[["dataset"]], out[["column"]]), , drop = FALSE]
 
 usethis::use_data(data_dictionary, overwrite = TRUE)

--- a/tests/testthat/test-add_sector_and_borderline.R
+++ b/tests/testthat/test-add_sector_and_borderline.R
@@ -1,25 +1,24 @@
-library(r2dii.data)
 # TODO: Instead of `loanbook_demo`, can use fake_lbk() everywhere?
 test_that("$borderline is of type logical", {
   expect_type(
-    add_sector_and_borderline(loanbook_demo)$borderline,
+    add_sector_and_borderline(r2dii.data::loanbook_demo)$borderline,
     "logical"
   )
 })
 
 test_that("returns a tibble data frame", {
   expect_s3_class(
-    add_sector_and_borderline(loanbook_demo),
+    add_sector_and_borderline(r2dii.data::loanbook_demo),
     "tbl_df"
   )
 })
 
 test_that("adds two columns: `sector` and `borderline`", {
-  expect_false(has_name(loanbook_demo, "sector"))
-  expect_false(has_name(loanbook_demo, "borderline"))
+  expect_false(has_name(r2dii.data::loanbook_demo, "sector"))
+  expect_false(has_name(r2dii.data::loanbook_demo, "borderline"))
 
-  out <- add_sector_and_borderline(loanbook_demo)
-  new_columns <- sort(setdiff(names(out), names(loanbook_demo)))
+  out <- add_sector_and_borderline(r2dii.data::loanbook_demo)
+  new_columns <- sort(setdiff(names(out), names(r2dii.data::loanbook_demo)))
   expect_equal(
     new_columns, c("borderline", "sector")
   )
@@ -41,25 +40,25 @@ test_that("added columns return acceptable values", {
 
   expect_true(
     all(
-      add_sector_and_borderline(loanbook_demo)$sector %in% acceptable_sectors
+      add_sector_and_borderline(r2dii.data::loanbook_demo)$sector %in% acceptable_sectors
     )
   )
 })
 
 test_that("preserves typeof() input columns", {
-  out <- add_sector_and_borderline(loanbook_demo)
+  out <- add_sector_and_borderline(r2dii.data::loanbook_demo)
 
-  x <- unname(purrr::map_chr(loanbook_demo, typeof))
-  y <- unname(purrr::map_chr(out[names(loanbook_demo)], typeof))
+  x <- unname(purrr::map_chr(r2dii.data::loanbook_demo, typeof))
+  y <- unname(purrr::map_chr(out[names(r2dii.data::loanbook_demo)], typeof))
   expect_equal(x, y)
 })
 
 test_that("outputs no missing value of `sector`", {
-  out <- add_sector_and_borderline(loanbook_demo)
+  out <- add_sector_and_borderline(r2dii.data::loanbook_demo)
   expect_false(any(is.na(out$sector)))
 })
 
 test_that("outputs no missing value of `borderline`", {
-  out <- add_sector_and_borderline(loanbook_demo)
+  out <- add_sector_and_borderline(r2dii.data::loanbook_demo)
   expect_false(any(is.na(out$borderline)))
 })

--- a/tests/testthat/test-data_dictionary.R
+++ b/tests/testthat/test-data_dictionary.R
@@ -1,6 +1,9 @@
 test_that("matches raw data dictionary CSVs", {
-  if (nzchar(Sys.getenv("R_CMD")) | nzchar(Sys.getenv("TESTTHAT_IS_CHECKING"))) {
-    skip("Not run in R CMD check or when using `testthat::test_check()`")
+  if (nzchar(Sys.getenv("R_CMD"))) {
+    skip("Not run in R CMD check (env var `R_CMD` is set)")
+  }
+  if (nzchar(Sys.getenv("TESTTHAT_IS_CHECKING"))) {
+    skip("Not run in `testthat::test_check()` (env var `TESTTHAT_IS_CHECKING` is set)")
   }
   
   paths <- list.files(test_path("../../data-raw/data_dictionary"), full.names = TRUE)

--- a/tests/testthat/test-data_dictionary.R
+++ b/tests/testthat/test-data_dictionary.R
@@ -1,6 +1,6 @@
 test_that("matches raw data dictionary CSVs", {
-  if (nzchar(Sys.getenv("R_CMD"))) {
-    skip("Not run in R CMD check")
+  if (nzchar(Sys.getenv("R_CMD")) | covr::in_covr()) {
+    skip("Not run in R CMD check or `covr::package_coverage()`")
   }
   
   paths <- list.files(test_path("../../data-raw/data_dictionary"), full.names = TRUE)

--- a/tests/testthat/test-data_dictionary.R
+++ b/tests/testthat/test-data_dictionary.R
@@ -1,4 +1,8 @@
 test_that("matches raw data dictionary CSVs", {
+  if (nzchar(Sys.getenv("R_CMD"))) {
+    skip("Not run in R CMD check")
+  }
+  
   paths <- list.files(test_path("../../data-raw/data_dictionary"), full.names = TRUE)
   out <- readr::read_csv(file = paths, show_col_types = FALSE)
   data_raw <- out[order(out[["dataset"]], out[["column"]]), , drop = FALSE]

--- a/tests/testthat/test-data_dictionary.R
+++ b/tests/testthat/test-data_dictionary.R
@@ -1,6 +1,6 @@
 test_that("matches raw data dictionary CSVs", {
-  if (nzchar(Sys.getenv("R_CMD")) | covr::in_covr()) {
-    skip("Not run in R CMD check or `covr::package_coverage()`")
+  if (nzchar(Sys.getenv("R_CMD")) | nzchar(Sys.getenv("TESTTHAT_IS_CHECKING"))) {
+    skip("Not run in R CMD check or when using `testthat::test_check()`")
   }
   
   paths <- list.files(test_path("../../data-raw/data_dictionary"), full.names = TRUE)

--- a/tests/testthat/test-data_dictionary.R
+++ b/tests/testthat/test-data_dictionary.R
@@ -1,0 +1,38 @@
+test_that("matches raw data dictionary CSVs", {
+  paths <- list.files(test_path("../../data-raw/data_dictionary"), full.names = TRUE)
+  out <- readr::read_csv(file = paths, show_col_types = FALSE)
+  data_raw <- out[order(out[["dataset"]], out[["column"]]), , drop = FALSE]
+
+  comp <- waldo::compare(data_raw, data_dictionary)
+
+  expect(
+    ok = length(comp) == 0,
+    failure_message = cli::format_message(c(
+      "{.var data_dictionary} does not match the raw data dictionary CSVs",
+      i = "You may need to manually run {.file data-raw/build_data_dictionary.R}",
+      comp
+    ))
+  )
+})
+
+test_that("columns are complete", {
+  expect(
+    ok = !any(is.na(data_dictionary[["dataset"]])),
+    failure_message = "the `dataset` column contains `NA` value/s"
+  )
+
+  expect(
+    ok = !any(is.na(data_dictionary[["column"]])),
+    failure_message = "the `column` column contains `NA` value/s"
+  )
+
+  expect(
+    ok = !any(is.na(data_dictionary[["typeof"]])),
+    failure_message = "the `typeof` column contains `NA` value/s"
+  )
+
+  expect(
+    ok = !any(is.na(data_dictionary[["definition"]])),
+    failure_message = "the `definition` column contains `NA` value/s"
+  )
+})

--- a/tests/testthat/test-match_name.R
+++ b/tests/testthat/test-match_name.R
@@ -1,6 +1,4 @@
 library(dplyr, warn.conflicts = FALSE)
-library(r2dii.data)
-
 
 test_that("w/ non-NA only at intermediate level yields matches at intermediate
           level only", {
@@ -134,26 +132,26 @@ test_that("w/ row 1 of loanbook and crucial cols yields expected", {
 test_that("w/ 1 row of full loanbook_demo yields expected names", {
   skip_if_r2dii_data_outdated()
 
-  out <- suppressWarnings(match_name(slice(loanbook_demo, 1L), fake_abcd()))
+  out <- suppressWarnings(match_name(slice(r2dii.data::loanbook_demo, 1L), fake_abcd()))
   expect_equal(names(out), expect_names_match_name)
 })
 
 test_that("takes unprepared loanbook and abcd datasets", {
-  expect_no_error(match_name(slice(loanbook_demo, 1), abcd_demo))
+  expect_no_error(match_name(slice(r2dii.data::loanbook_demo, 1), r2dii.data::abcd_demo))
 })
 
 test_that("w/ loanbook that matches nothing, yields expected", {
   skip_if_r2dii_data_outdated()
 
   # Matches zero row ...
-  lbk2 <- slice(loanbook_demo, 2)
+  lbk2 <- slice(r2dii.data::loanbook_demo, 2)
   lbk2 <- mutate(
     lbk2,
     name_direct_loantaker = "Foo",
     name_ultimate_parent = "Bar"
   )
   expect_warning(
-    out <- match_name(lbk2, slice(abcd_demo, 1:10)),
+    out <- match_name(lbk2, slice(r2dii.data::abcd_demo, 1:10)),
     "no match"
   )
   expect_equal(nrow(out), 0L)
@@ -169,9 +167,9 @@ test_that("w/ 2 lbk rows matching 2 abcd rows, yields expected names", {
   skip_if_r2dii_data_outdated()
 
   # Slice 5 once was problematic (#85)
-  lbk45 <- slice(loanbook_demo, 4:5)
+  lbk45 <- slice(r2dii.data::loanbook_demo, 4:5)
   expect_named(
-    match_name(lbk45, abcd_demo),
+    match_name(lbk45, r2dii.data::abcd_demo),
     expect_names_match_name
   )
 })
@@ -179,17 +177,17 @@ test_that("w/ 2 lbk rows matching 2 abcd rows, yields expected names", {
 test_that("w/ 1 lbk row matching ultimate, yields expected names", {
   skip_if_r2dii_data_outdated()
 
-  lbk1 <- slice(loanbook_demo, 1)
+  lbk1 <- slice(r2dii.data::loanbook_demo, 1)
 
   expect_named(
-    match_name(lbk1, abcd_demo),
+    match_name(lbk1, r2dii.data::abcd_demo),
     expect_names_match_name
   )
 })
 
 test_that("takes `min_score`", {
   expect_no_error(
-    match_name(slice(loanbook_demo, 1), abcd_demo, min_score = 0.5)
+    match_name(slice(r2dii.data::loanbook_demo, 1), r2dii.data::abcd_demo, min_score = 0.5)
   )
 })
 
@@ -199,8 +197,8 @@ test_that("takes `method`", {
 
   expect_false(
     identical(
-      match_name(lbk_method, abcd_demo, method = "jw"),
-      match_name(lbk_method, abcd_demo, method = "osa")
+      match_name(lbk_method, r2dii.data::abcd_demo, method = "jw"),
+      match_name(lbk_method, r2dii.data::abcd_demo, method = "osa")
     )
   )
 })
@@ -211,14 +209,14 @@ test_that("takes `p`", {
 
   expect_false(
     identical(
-      match_name(lbk_p, abcd_demo, p = 0.1),
-      match_name(lbk_p, abcd_demo, p = 0.2)
+      match_name(lbk_p, r2dii.data::abcd_demo, p = 0.1),
+      match_name(lbk_p, r2dii.data::abcd_demo, p = 0.2)
     )
   )
 })
 
 test_that("takes `overwrite`", {
-  lbk <- slice(loanbook_demo, 4:25)
+  lbk <- slice(r2dii.data::loanbook_demo, 4:25)
   overwrite_demo <- tibble(
     level = "ultimate_parent",
     id_2dii = "UP1",
@@ -229,14 +227,14 @@ test_that("takes `overwrite`", {
 
   expect_false(
     identical(
-      match_name(lbk, abcd_demo, overwrite = NULL),
-      suppressWarnings(match_name(lbk, abcd_demo, overwrite = overwrite_demo))
+      match_name(lbk, r2dii.data::abcd_demo, overwrite = NULL),
+      suppressWarnings(match_name(lbk, r2dii.data::abcd_demo, overwrite = overwrite_demo))
     )
   )
 })
 
 test_that("warns overwrite", {
-  lbk <- slice(loanbook_demo, 4:25)
+  lbk <- slice(r2dii.data::loanbook_demo, 4:25)
   overwrite_demo <- tibble(
     level = "ultimate_parent",
     id_2dii = "UP1",
@@ -245,7 +243,7 @@ test_that("warns overwrite", {
     source = "manual"
   )
   expect_warning(
-    match_name(lbk, abcd_demo, overwrite = overwrite_demo),
+    match_name(lbk, r2dii.data::abcd_demo, overwrite = overwrite_demo),
     class = "overwrite_warning"
   )
 })
@@ -253,7 +251,7 @@ test_that("warns overwrite", {
 test_that("recovers `sector_lbk`", {
   expect_true(
     rlang::has_name(
-      match_name(slice(loanbook_demo, 1), abcd_demo),
+      match_name(slice(r2dii.data::loanbook_demo, 1), r2dii.data::abcd_demo),
       "sector"
     )
   )
@@ -261,27 +259,27 @@ test_that("recovers `sector_lbk`", {
 
 test_that("recovers `sector_abcd`", {
   expect_true(
-    rlang::has_name(match_name(loanbook_demo, abcd_demo), "sector_abcd")
+    rlang::has_name(match_name(r2dii.data::loanbook_demo, r2dii.data::abcd_demo), "sector_abcd")
   )
 })
 
 test_that("outputs name from loanbook, not name.y (bug fix)", {
-  out <- match_name(slice(loanbook_demo, 1), abcd_demo)
+  out <- match_name(slice(r2dii.data::loanbook_demo, 1), r2dii.data::abcd_demo)
   expect_false(has_name(out, "name.y"))
 })
 
 test_that("works with `min_score = 0` (bug fix)", {
-  expect_no_error(match_name(slice(loanbook_demo, 1), abcd_demo, min_score = 0))
+  expect_no_error(match_name(slice(r2dii.data::loanbook_demo, 1), r2dii.data::abcd_demo, min_score = 0))
 })
 
 test_that("outputs only perfect matches if any (#40 @2diiKlaus)", {
   this_name <- "Ladeck"
   this_alias <- to_alias(this_name)
-  this_lbk <- loanbook_demo %>%
+  this_lbk <- r2dii.data::loanbook_demo %>%
     filter(name_direct_loantaker == this_name)
 
   scores <- this_lbk %>%
-    match_name(abcd_demo) %>%
+    match_name(r2dii.data::abcd_demo) %>%
     mutate(alias = to_alias(name)) %>%
     filter(alias == this_alias) %>%
     pull(score)
@@ -295,7 +293,7 @@ test_that("outputs only perfect matches if any (#40 @2diiKlaus)", {
 })
 
 test_that("match_name()$level lacks prefix 'name_' suffix '_lbk'", {
-  out <- match_name(slice(loanbook_demo, 1), abcd_demo)
+  out <- match_name(slice(r2dii.data::loanbook_demo, 1), r2dii.data::abcd_demo)
   expect_false(
     any(startsWith(unique(out$level), "name_"))
   )
@@ -305,20 +303,20 @@ test_that("match_name()$level lacks prefix 'name_' suffix '_lbk'", {
 })
 
 test_that("preserves groups", {
-  grouped_loanbook <- slice(loanbook_demo, 1) %>%
+  grouped_loanbook <- slice(r2dii.data::loanbook_demo, 1) %>%
     group_by(id_loan)
 
-  expect_true(is_grouped_df(match_name(grouped_loanbook, abcd_demo)))
+  expect_true(is_grouped_df(match_name(grouped_loanbook, r2dii.data::abcd_demo)))
 })
 
 test_that("outputs id consistent with level", {
-  out <- slice(loanbook_demo, 6) %>% match_name(abcd_demo)
+  out <- slice(r2dii.data::loanbook_demo, 6) %>% match_name(r2dii.data::abcd_demo)
   expect_equal(out$level, c("direct_loantaker", "ultimate_parent"))
   expect_equal(out$id_2dii, c("DL1", "UP1"))
 })
 
 test_that("no longer yiels all NAs in lbk columns (#85 @jdhoffa)", {
-  out <- match_name(loanbook_demo, abcd_demo)
+  out <- match_name(r2dii.data::loanbook_demo, r2dii.data::abcd_demo)
   out_lbk_cols <- out %>%
     select(
       setdiff(
@@ -458,10 +456,10 @@ test_that("w/ overwrite with missing names errors gracefully", {
 })
 
 test_that("with bad input errors gracefully", {
-  bad_loanbook <- loanbook_demo %>%
+  bad_loanbook <- r2dii.data::loanbook_demo %>%
     mutate(name_direct_loantaker = as.numeric(12))
 
-  expect_no_error(match_name(bad_loanbook, abcd_demo))
+  expect_no_error(match_name(bad_loanbook, r2dii.data::abcd_demo))
 })
 
 test_that("with name_intermediate but not id_intermediate throws an error", {
@@ -472,13 +470,13 @@ test_that("with name_intermediate but not id_intermediate throws an error", {
 })
 
 test_that("0-row output has expected column type", {
-  lbk2 <- slice(loanbook_demo, 2)
+  lbk2 <- slice(r2dii.data::loanbook_demo, 2)
   lbk2 <- mutate(
     lbk2,
     name_direct_loantaker = "Foo",
     name_ultimate_parent = "Bar"
   )
-  out <- suppressWarnings(match_name(lbk2, abcd_demo))
+  out <- suppressWarnings(match_name(lbk2, r2dii.data::abcd_demo))
 
   lbk_types <- purrr::map_chr(lbk2, typeof)
   out_types <- purrr::map_chr(out, typeof)
@@ -506,8 +504,8 @@ test_that("takes `by_sector`", {
   skip_if_r2dii_data_outdated()
   expect_false(
     identical(
-      match_name(slice(loanbook_demo, 4:15), abcd_demo, by_sector = TRUE),
-      match_name(slice(loanbook_demo, 4:15), abcd_demo, by_sector = FALSE)
+      match_name(slice(r2dii.data::loanbook_demo, 4:15), r2dii.data::abcd_demo, by_sector = TRUE),
+      match_name(slice(r2dii.data::loanbook_demo, 4:15), r2dii.data::abcd_demo, by_sector = FALSE)
     )
   )
 })

--- a/tests/testthat/test-prioritize.R
+++ b/tests/testthat/test-prioritize.R
@@ -1,11 +1,10 @@
 library(dplyr, warn.conflicts = FALSE)
-library(r2dii.data)
 
 test_that("w/ full demo datasets throws no error", {
   expect_no_error(
-    loanbook_demo %>%
+    r2dii.data::loanbook_demo %>%
       slice(4:5) %>%
-      match_name(abcd_demo) %>%
+      match_name(r2dii.data::abcd_demo) %>%
       prioritize(priority = "ultimate_parent")
   )
 })

--- a/tests/testthat/test-restructure_abcd.R
+++ b/tests/testthat/test-restructure_abcd.R
@@ -1,6 +1,4 @@
-library(r2dii.data)
-
-loanbook_rowid <- loanbook_demo %>%
+loanbook_rowid <- r2dii.data::loanbook_demo %>%
   tibble::rowid_to_column()
 
 test_that("may input add_sector_and_borderline(data)", {
@@ -21,7 +19,7 @@ test_that("errors gracefully with bad input", {
 })
 
 test_that("correctly overwrites name", {
-  overwrite <- overwrite_demo
+  overwrite <- r2dii.data::overwrite_demo
 
   out <- suppressWarnings(
     restructure_loanbook(loanbook_rowid, overwrite)
@@ -33,7 +31,7 @@ test_that("correctly overwrites name", {
 })
 
 test_that("correctly overwrites sector", {
-  overwrite <- overwrite_demo
+  overwrite <- r2dii.data::overwrite_demo
 
   out <- suppressWarnings(
     restructure_loanbook(loanbook_rowid, overwrite)

--- a/tests/testthat/test-uniquify_id_column.R
+++ b/tests/testthat/test-uniquify_id_column.R
@@ -1,7 +1,5 @@
-library(r2dii.data)
-
 test_that("uniquify_id_column overwrites id_ultimate_parent", {
-  lbk <- loanbook_demo
+  lbk <- r2dii.data::loanbook_demo
   lbk$id_ultimate_parent <- "bla"
 
   out <- uniquify_id_column(lbk, id_column = "id_ultimate_parent")
@@ -15,7 +13,7 @@ test_that("uniquify_id_column overwrites id_ultimate_parent", {
 })
 
 test_that("uniquify_id_column overwrites id_direct_loantaker", {
-  lbk <- loanbook_demo
+  lbk <- r2dii.data::loanbook_demo
   lbk$id_direct_loantaker <- "bla"
 
   out <- uniquify_id_column(lbk, id_column = "id_direct_loantaker")
@@ -33,7 +31,7 @@ test_that("uniquify_id_column prints its output (fix not returned result)", {
   # 6#pullrequestreview-301599396
   out <- capture.output(
     uniquify_id_column(
-      loanbook_demo,
+      r2dii.data::loanbook_demo,
       id_column = "id_ultimate_parent"
     )
   )


### PR DESCRIPTION
- depends on #525 
- depends on #528 

⚠️ I also had to remove `library(r2dii.data)` calls in other tests and namespace all datasets from {r2dii.data} to avoid `r2dii.data::data_dictionary` unexpectedly overriding `r2dii.match::data_dictionary`