### PR TITLE
remove resetting of option which is no longer relevant

### DIFF
--- a/R/match_name.R
+++ b/R/match_name.R
@@ -116,9 +116,6 @@
 #' )
 #'
 #' match_name(loanbook, abcd, sector_classification = your_classifications)
-#'
-#' # Cleanup
-#' options(restore)
 #' }
 match_name <- function(loanbook,
                        abcd,

--- a/man/match_name.Rd
+++ b/man/match_name.Rd
@@ -157,9 +157,6 @@ abcd <- tibble(
 )
 
 match_name(loanbook, abcd, sector_classification = your_classifications)
-
-# Cleanup
-options(restore)
 }
 }
 \seealso{


### PR DESCRIPTION
In #509 I added the custom sector classification feature through an argument rather than by setting an option, but when I modified the example code I did not remove the final resetting of the option back to the original.