### PR TITLE
remove dontrun directive from `match_name()` example

### DIFF
--- a/R/match_name.R
+++ b/R/match_name.R
@@ -62,7 +62,6 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
 #' library(r2dii.data)
 #' library(tibble)
 #'
@@ -119,7 +118,6 @@
 #'
 #' # Cleanup
 #' options(restore)
-#' }
 match_name <- function(loanbook,
                        abcd,
                        by_sector = TRUE,

--- a/man/match_name.Rd
+++ b/man/match_name.Rd
@@ -103,7 +103,6 @@ This function ignores but preserves existing groups.
 }
 
 \examples{
-\dontrun{
 library(r2dii.data)
 library(tibble)
 
@@ -160,7 +159,6 @@ match_name(loanbook, abcd, sector_classification = your_classifications)
 
 # Cleanup
 options(restore)
-}
 }
 \seealso{
 Other main functions: 


### PR DESCRIPTION
- depends on #532 (otherwise example fails on missing `restore`)

In https://github.com/RMI-PACTA/r2dii.match/commit/76a7e8bb91836515b524bb978bda8cb0193e7f24 the dontrun directive was added to the `match_name()` example with no explanation, but this led to CRAN refusal of pacta.loanbook (which imports `r2dii.match::match_name()` and its documentation) and it seems to run fine, especially with the "small data" used in the example, so maybe we should let it run?